### PR TITLE
fixes in cea_obj_w_units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ ENV/
 rocketcea/tests/__pycache__/test_misc.cpython-37.pyc
 *.pyc
 install_w_py38.txt
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/

--- a/rocketcea/cea_obj_w_units.py
+++ b/rocketcea/cea_obj_w_units.py
@@ -359,7 +359,7 @@ class CEA_Obj( object ):
         Pc = self.Pc_U.uval_to_dval( Pc ) # convert user units to psia
         Cp, visc, cond, Prandtl = self.cea_obj.get_Exit_Transport( Pc=Pc, MR=MR, eps=eps, frozen=frozen)
         
-        Cp = Cp * 8314.51 / 4184.0  # convert into BTU/lbm degR
+        #Cp = Cp * 8314.51 / 4184.0  # convert into BTU/lbm degR
         Cp = self.specific_heat_U.dval_to_uval( Cp )
         visc = self.viscosity_U.dval_to_uval( visc )
         cond = self.thermal_cond_U.dval_to_uval( cond )

--- a/rocketcea/cea_obj_w_units.py
+++ b/rocketcea/cea_obj_w_units.py
@@ -258,10 +258,10 @@ class CEA_Obj( object ):
         
         return cpList
         
-    def get_Chamber_Cp(self, Pc=100.0, MR=1.0, eps=40.0):
+    def get_Chamber_Cp(self, Pc=100.0, MR=1.0, eps=40.0, frozen=0):
         
         Pc = self.Pc_U.uval_to_dval( Pc ) # convert user units to psia
-        Cp = self.cea_obj.get_Chamber_Cp( Pc=Pc, MR=MR, eps=eps )
+        Cp = self.cea_obj.get_Chamber_Cp( Pc=Pc, MR=MR, eps=eps, frozen=frozen )
         return self.specific_heat_U.dval_to_uval( Cp )
         
     def get_Throat_Isp(self, Pc=100.0, MR=1.0, frozen=0):
@@ -282,10 +282,10 @@ class CEA_Obj( object ):
         Pc = self.Pc_U.uval_to_dval( Pc ) # convert user units to psia
         return self.cea_obj.get_Throat_MolWt_gamma( Pc=Pc, MR=MR, eps=eps, frozen=frozen )
         
-    def get_exit_MolWt_gamma(self, Pc=100.0, MR=1.0, eps=40.0):
+    def get_exit_MolWt_gamma(self, Pc=100.0, MR=1.0, eps=40.0, frozen=0, frozenAtThroat=0):
         
         Pc = self.Pc_U.uval_to_dval( Pc ) # convert user units to psia
-        return self.cea_obj.get_exit_MolWt_gamma( Pc=Pc, MR=MR, eps=eps )
+        return self.cea_obj.get_exit_MolWt_gamma( Pc=Pc, MR=MR, eps=eps, frozen=frozen, frozenAtThroat=frozenAtThroat )
         
     def get_eqratio(self, Pc=100.0, MR=1.0, eps=40.0):
         


### PR DESCRIPTION
1. 🇺🇸  Fixed the conversion from imperial units 🇬🇧  to user units 🇫🇷 in get_Exit_Transport()
2. 🚀 Added missing arguments to member functions of cea_obj_w_units
    ↳ get_Chamber_Cp() : added frozen=0
    ↳ get_exit_MolWt_gamma() : added frozen=0, frozenAtThroat=0