### PR TITLE
make_reading_prints in cea_obj_w_units

### DIFF
--- a/rocketcea/cea_obj_w_units.py
+++ b/rocketcea/cea_obj_w_units.py
@@ -19,7 +19,7 @@ class CEA_Obj( object ):
         sonic_velocity_units='ft/sec', enthalpy_units='BTU/lbm', 
         density_units='lbm/cuft', specific_heat_units='BTU/lbm degR',
         viscosity_units='millipoise', thermal_cond_units='mcal/cm-K-s', 
-        fac_CR=None, make_debug_prints=False):
+        fac_CR=None, make_debug_prints=False, make_reading_prints=False):
         """::
         
         #: RocketCEA wraps the NASA FORTRAN CEA code to calculate Isp, cstar, and Tcomb
@@ -68,7 +68,8 @@ class CEA_Obj( object ):
         
         self.cea_obj = CEA_Obj_default(propName=propName, oxName=oxName, fuelName=fuelName, 
                                useFastLookup=useFastLookup, makeOutput=makeOutput,
-                               fac_CR=fac_CR, make_debug_prints=make_debug_prints)
+                               fac_CR=fac_CR, make_debug_prints=make_debug_prints,
+                               make_reading_prints=make_reading_prints)
         self.desc = self.cea_obj.desc
     
     def get_IvacCstrTc(self, Pc=100.0, MR=1.0, eps=40.0, frozen=0, frozenAtThroat=0):


### PR DESCRIPTION
Hi,
I extended the make_reading_prints statement to cea_obj_w_units, allowing users to control whether the "reading CEA ISP data files for ... times" message is printed when RocketCEA is run repeatedly.